### PR TITLE
property paths can contain the : character, e.g. for tilesets

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -88,7 +88,7 @@ module.exports = grammar({
     // 0/texture = ExtResource( 2 )
     _properties: ($) => repeat1($.property),
     property: ($) => seq($.path, "=", $._value),
-    path: ($) => /[a-zA-Z_0-9][a-zA-Z_/0-9]*/,
+    path: ($) => /[a-zA-Z_0-9][a-zA-Z_:/0-9]*/,
 
     // -----------------------------------------------------------------------------
     // -                                 Data Structs                              -

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -430,7 +430,7 @@
     },
     "path": {
       "type": "PATTERN",
-      "value": "[a-zA-Z_0-9][a-zA-Z_/0-9]*"
+      "value": "[a-zA-Z_0-9][a-zA-Z_:/0-9]*"
     },
     "pair": {
       "type": "SEQ",

--- a/src/parser.c
+++ b/src/parser.c
@@ -626,7 +626,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       END_STATE();
     case 34:
       ACCEPT_TOKEN(sym_path);
-      if (('/' <= lookahead && lookahead <= '9') ||
+      if (('/' <= lookahead && lookahead <= ':') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
           ('a' <= lookahead && lookahead <= 'z')) ADVANCE(34);


### PR DESCRIPTION
Couldn't parse a tileset due to lines like:

```
10:0/0 = 0
```

under a TileSetAtlasSource sub_resource. This seems to fix it, and it looks like the 'path' regex isn't used elsewhere. I'm assuming that it's probably not valid to start with a colon, though.